### PR TITLE
Remove no-op expressions

### DIFF
--- a/misc/soundServer.js
+++ b/misc/soundServer.js
@@ -107,7 +107,6 @@ var SoundItem = class {
     }
 
     get Status() {
-        void this;
         return SoundItemStatusEnum;
     }
 

--- a/service.js
+++ b/service.js
@@ -64,7 +64,6 @@ var Service = class {
     }
 
     MinimizeAll() {
-        void this;
         global.get_window_actors().forEach(actor => {
             actor.metaWindow.minimize();
         });
@@ -79,7 +78,6 @@ var Service = class {
     }
 
     get FocusedApp() {
-        void this;
         let appId = '';
         const tracker = Shell.WindowTracker.get_default();
         if (tracker.focus_app)
@@ -88,82 +86,66 @@ var Service = class {
     }
 
     get HackModeEnabled() {
-        void this;
         return Settings.get_boolean('hack-mode-enabled');
     }
 
     set HackModeEnabled(enabled) {
-        void this;
         Settings.set_boolean('hack-mode-enabled', enabled);
     }
 
     get HackIconPulse() {
-        void this;
         return Settings.get_boolean('hack-icon-pulse');
     }
 
     set HackIconPulse(enabled) {
-        void this;
         Settings.set_boolean('hack-icon-pulse', enabled);
     }
 
     get ShowHackLauncher() {
-        void this;
         return Settings.get_boolean('show-hack-launcher');
     }
 
     set ShowHackLauncher(enabled) {
-        void this;
         Settings.set_boolean('show-hack-launcher', enabled);
     }
 
     get WobblyEffect() {
-        void this;
         return Settings.get_boolean('wobbly-effect');
     }
 
     set WobblyEffect(enabled) {
-        void this;
         Settings.set_boolean('wobbly-effect', enabled);
     }
 
     get WobblySpringK() {
-        void this;
         return Settings.get_double('wobbly-spring-k');
     }
 
     set WobblySpringK(value) {
-        void this;
         Settings.set_double('wobbly-spring-k', value);
     }
 
     get WobblySpringFriction() {
-        void this;
         return Settings.get_double('wobbly-spring-friction');
     }
 
     set WobblySpringFriction(value) {
-        void this;
         Settings.set_double('wobbly-spring-friction', value);
     }
 
     get WobblySlowdownFactor() {
-        void this;
         return Settings.get_double('wobbly-slowdown-factor');
     }
 
     set WobblySlowdownFactor(value) {
-        void this;
         Settings.set_double('wobbly-slowdown-factor', value);
     }
 
     get WobblyObjectMovementRange() {
-        void this;
         return Settings.get_double('wobbly-object-movement-range');
     }
 
     set WobblyObjectMovementRange(value) {
-        void this;
         Settings.set_double('wobbly-object-movement-range', value);
     }
 };

--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -135,13 +135,11 @@ class HackAppIcon extends AppDisplay.AppIcon {
     }
 
     _canAccept() {
-        void this;
         return false;
     }
 
     // Override to avoid animation on launch
     animateLaunch() {
-        void this;
     }
 
     remove() {
@@ -150,7 +148,6 @@ class HackAppIcon extends AppDisplay.AppIcon {
     }
 
     get name() {
-        void this;
         return 'Hack';
     }
 
@@ -165,12 +162,10 @@ class HackAppIcon extends AppDisplay.AppIcon {
     }
 
     handleDragOver() {
-        void this;
         return DND.DragMotionResult.NO_DROP;
     }
 
     acceptDrop() {
-        void this;
         // This will catch the drop event and do nothing
         return true;
     }

--- a/ui/clubhouse.js
+++ b/ui/clubhouse.js
@@ -230,8 +230,6 @@ var ClubhouseAnimator = class ClubhouseAnimator {
     }
 
     _getActivateDir(deployDir) {
-        void this;
-
         // Replace the hash part of the deploy directory by "active", so the directory
         // is always the most recent one (i.e. allows us to update the Clubhouse and
         // still have the right dir).
@@ -583,7 +581,6 @@ class ClubhouseNotificationBanner extends MessageTray.NotificationBanner {
 
     _onClicked() {
         // Do nothing because we don't want to activate the Clubhouse ATM
-        void this;
     }
 
     _setNextPage() {
@@ -1033,7 +1030,6 @@ var Component = GObject.registerClass({
     }
 
     _imageUsesClubhouse() {
-        void this;
         return Settings.get_boolean('hack-mode-enabled');
     }
 

--- a/ui/codeView.js
+++ b/ui/codeView.js
@@ -1258,7 +1258,6 @@ var CodingSession = GObject.registerClass({
     }
 
     _playAnimationSound(direction) {
-        void this;
         if (direction === Gtk.DirectionType.LEFT)
             SoundServer.getDefault().play('shell/tracking-button/flip/click');
         else
@@ -1498,7 +1497,6 @@ var CodeViewManager = GObject.registerClass({
     }
 
     _isClubhouseInstalled() {
-        void this;
         return Clubhouse.getClubhouseApp() || Clubhouse.getClubhouseApp('com.endlessm.Clubhouse');
     }
 

--- a/ui/wobbly.js
+++ b/ui/wobbly.js
@@ -52,7 +52,6 @@ var ControllableShellWobblyEffect = GObject.registerClass({
     },
 }, class ControllableShellWobblyEffect extends GObject.Object {
     vfunc_get_name() {
-        void this;
         return 'wobbly';
     }
 
@@ -71,7 +70,6 @@ var ControllableShellWobblyEffect = GObject.registerClass({
 var GSettingsShellWobblyEffect = GObject.registerClass({
 }, class GSettingsShellWobblyEffect extends ControllableShellWobblyEffect {
     vfunc_get_name() {
-        void this;
         return 'gsettings-wobbly';
     }
 
@@ -122,7 +120,6 @@ var EOSShellWobbly = GObject.registerClass({
     }
 
     grabbedByMouse() {
-        void this;
     }
 
     activate(event, detail) {
@@ -213,7 +210,6 @@ var ShellWindowManagerAnimatableSurface = GObject.registerClass({
     }
 
     vfunc_detach_effect(event, attachedEffect) {
-        void this;
         attachedEffect.remove();
     }
 
@@ -231,7 +227,6 @@ var ShellWindowManagerAnimatableSurface = GObject.registerClass({
     }
 
     vfunc_get_available_effects() {
-        void this;
         return new GLib.Variant('a{sv}',
             Object.keys(_ALLOWED_ANIMATIONS_FOR_EVENTS).reduce(
                 (acc, key) => {
@@ -255,7 +250,6 @@ const ShellWindowManagerAnimationsFactory = GObject.registerClass({
     Implements: [AnimationsDbus.ServerEffectFactory],
 }, class ShellWindowManagerAnimationsFactory extends GObject.Object {
     vfunc_create_effect(name) {
-        void this;
         switch (name) {
         case 'wobbly':
             return new ControllableShellWobblyEffect();


### PR DESCRIPTION
The code has several places with the expression "void this" which cause warnings
like the following:

  endless-master gnome-shell[5319]: JS WARNING: [/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/ui/appDisplay.js 138]: useless expression
  endless-master gnome-shell[5319]: JS WARNING: [/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/ui/clubhouse.js 233]: useless expression

Let's remove these no-op expressions.

https://phabricator.endlessm.com/T28568