### PR TITLE
appDisplay: Don't override ViewIcon._canAccept

### DIFF
--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -286,14 +286,6 @@ function enable() {
         return Utils.original(AppDisplay.BaseAppView, '_canAccept').bind(this)(source);
     });
 
-    Utils.override(AppDisplay.ViewIcon, '_canAccept', source => {
-        // Disable movement of the HackAppIcon
-        if (source instanceof HackAppIcon)
-            return false;
-
-        return true;
-    });
-
     Utils.override(AppDisplay.FolderIcon, '_canAccept', function(source) {
         // Disable movement of the HackAppIcon
         if (source instanceof HackAppIcon)
@@ -318,7 +310,6 @@ function disable() {
     HackIcons = new Utils.ObjectsMap();
 
     Utils.restore(AppDisplay.BaseAppView);
-    Utils.restore(AppDisplay.ViewIcon);
     Utils.restore(AppDisplay.FolderIcon);
     Utils.restore(AppDisplay.AppIcon);
 


### PR DESCRIPTION
Let me tell you a story about a family. It wasn't like any other
family, for it was a proto-family.

The proto-parent was responsible and serious. Proto-parent had
3 children: proto-app, proto-folder, and proto-store. They all
specialized in different tasks, but they were all under
proto-parent's supervision. Whenever they didn't know what to
do, or when proto-parent knew better, they'd ask proto-parent
to help them.

One day, this beautifully working proto-family heard their door
bells ring.

 - "Who's there?", asked proto-parent
 - "Hi. So, uh… I need shelter. I'm your child, proto-parent."

Proto-parent froze for a second. The proto-children wouldn't
be able to handle that. They had an unknown sibling?! Nope,
that was too much.

 - "You have to let me in. The garbage collector won't let me
    live long if I'm spotted! My life's at risk!"

Proto-parent opened the hourse doors and let the stranger in.
The proto-children stood still, waiting for an explanation.
Proto-parent tried to choose the best words, but words wouldn't
come.

 - "Can we at least know your name, stranger?", said proto-app.
 - "Sorry. My name is proto-hack."
 - "Wait, what? You're part of the proto-family?!", said shocked
   proto-folder.
 - "Sorry. Yes. I apologize that we met this way…", answered
   proto-hack, visibly shy and concerned.

Little did proto-parent know that proto-hack was more than a mere
proto-child. Proto-hack quickly modified the _canAccept tools of
all the proto-family! Even proto-parent's, but proto-parent didn't
have a _canAccept tool. Proto-parent quickly learned how to use
this new tool, and the proto-family carried on, with a new member.

Proto-hack didn't notice at the time, but proto-parent was, in fact,
an over-achiever: it would use its new _canAccept tool despite
proto-folder having one. That turned out to be problematic, since
proto-folder was… let's say, more aware of the intricacies of
_canAccept than proto-parent, in such a way that proto-parent
couldn't know. This was resulting in odd results.

The proto-family was sad. They were known to produce good results.
After much struggle and misery, they all heard a faint voice:

 - "Thou shalt remove proto-parent's _canAccept, as thy art better
    a fit for a tool", a heavenly voice whispered to proto-folder

Stunned, but delighted, proto-folder removed proto-parent's new
tool, and to much of everyone's surprise, results were correct
once again.

And this is the tale of the proto-family.

https://phabricator.endlessm.com/T29720