### PR TITLE
appDisplay: Fix signature of overriden method IconGridLayout.removeIcon

### DIFF
--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -268,13 +268,13 @@ function enable() {
 
         return newApps;
     });
-    Utils.override(IconGridLayout.IconGridLayout, 'removeIcon', function(id) {
+    Utils.override(IconGridLayout.IconGridLayout, 'removeIcon', function(id, interactive) {
         if (id === CLUBHOUSE_ID) {
             HackIcons.forEach((k, v) => v.remove());
             return;
         }
 
-        Utils.original(IconGridLayout.IconGridLayout, 'removeIcon').bind(this)(id);
+        Utils.original(IconGridLayout.IconGridLayout, 'removeIcon').bind(this)(id, interactive);
     });
 
     // Disable movements


### PR DESCRIPTION
The signature must match the one for the overriden method.
This caused an issue where the 'Remove from desktop' action was invoking
IconGridLayout.removeIcon() with the 'interactive' param set to true but
the method would always receive 'interactive' as undefined because this
overriden method wasn't forwarding the flag.

https://phabricator.endlessm.com/T29782