### PR TITLE
autostart: Add autostart desktop file to set Hack flatpak permissions

### DIFF
--- a/autostart/com.hack_computer.Clubhouse-flatpak-permissions.desktop
+++ b/autostart/com.hack_computer.Clubhouse-flatpak-permissions.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Hack Clubhouse Permissions
+Comment=Sets the default flatpak permissions for the Hack Clubhouse
+# FIXME: Workaround for the lack of system-level defaults for flatpak permissions
+# See https://github.com/flatpak/xdg-desktop-portal/issues/471
+# and https://phabricator.endlessm.com/T29677
+Exec=/usr/bin/sh -c "export FLATPAK_FANCY_OUTPUT=0; if ! flatpak permission-list background background | grep -q '[[:space:]]com.hack_computer.Clubhouse[[:space:]]'; then flatpak permission-set background background com.hack_computer.Clubhouse yes || true; fi"
+OnlyShowIn=GNOME;
+X-GNOME-Autostart-Phase=Application

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,8 @@ install_subdir('data', install_dir: join_paths(extensiondir, uuid))
 install_subdir('misc', install_dir: join_paths(extensiondir, uuid))
 install_subdir('ui', install_dir: join_paths(extensiondir, uuid))
 
+install_subdir('autostart', install_dir: join_paths(datadir, 'gnome'), strip_directory: false)
+
 glib_compile = find_program('glib-compile-schemas', required: true)
 schemas_files = []
 foreach s : schemas


### PR DESCRIPTION
Flatpak (correctly) warns the user about Hack continuing to run as a
background process after they’ve closed the Hack window. As Hack is
designed to do that (so that it can integrate further into the desktop),
set the permissions in the xdg-desktop-portal database so that Hack is
allowed to run in the background, and the user isn’t notified about it.

It has to be done on startup so all users have the permissions set in
their session (xdg-desktop-portal provides no system-wide configuration
hook), and it can’t be done from within Hack as that would require
breaking the flatpak sandboxing.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T29677