### PR TITLE
utils: Don't override gettext domain for entire shell

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,10 +1,9 @@
 /* exported getSettings, loadInterfaceXML, override, restore, original, tryMigrateSettings, ObjectsMap, gettext */
 
 const { Gio } = imports.gi;
-const Gettext = imports.gettext;
+const Gettext = imports.gettext.domain('hack-extension');
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 
-Gettext.textdomain('hack-extension')
 var gettext = Gettext.gettext;
 
 function getMigrationSettings() {


### PR DESCRIPTION
imports.gettext.textdomain() calls the textdomain() C library function,
which changes the global default textdomain for the entire process.

imports.gettext.domain(d) returns an object whose gettext() method calls
the C function dgettext(), passing the domain d.

This fixes looking up translations in the shell at large after the Hack
extension is loaded.

https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/core/_gettext.js
https://phabricator.endlessm.com/T30369