### PR TITLE
WIP: hackfx: Add code_view_effect

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
-project('hack-extension',
+project('hack-extension', 'c',
   version: '3.8.0',
-  meson_version: '>= 0.40.0'
+  meson_version: '>= 0.47.0'
 )
 
 sources = [
@@ -106,3 +106,5 @@ if extension_tool.found()
 
   run_target('zip-file', command: command)
 endif
+
+subdir('src')

--- a/src/hackfx-code-view-effect.c
+++ b/src/hackfx-code-view-effect.c
@@ -1,0 +1,301 @@
+/*
+ * hackfx-code-view-effect.c
+ *
+ * Based on clutter-desaturate-effect.c.
+ *
+ * Copyright (C) 2010  Intel Corporation.
+ * Copyright (C) 2018  Endless Mobile, Inc.
+ * Copyright (C) 2020  Endless OS LLC.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *   Emmanuele Bassi <ebassi@linux.intel.com>
+ *   Cosimo Cecchi <cosimo@endlessm.com>
+ *   Daniel Garcia Moreno <daniel@endlessm.com>
+ */
+
+#include <math.h>
+
+#include "hackfx-code-view-effect.h"
+
+#include <cogl/cogl.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct
+{
+  ClutterColor gradient_colors[5];
+  gfloat gradient_points[5];
+
+  gint gradient_colors_uniform;
+  gint gradient_points_uniform;
+
+  CoglPipeline *pipeline;
+} HackfxCodeViewEffectPrivate;
+
+struct _HackfxCodeViewEffectClass
+{
+  ClutterOffscreenEffectClass parent_class;
+
+  CoglPipeline *base_pipeline;
+};
+
+/* the magic gray vec3 has been taken from the NTSC conversion weights
+ * as defined by:
+ *
+ *   "OpenGL Superbible, 4th edition"
+ *   -- Richard S. Wright Jr, Benjamin Lipchak, Nicholas Haemel
+ *   Addison-Wesley
+ */
+static const gchar *glsl_declarations =
+  "uniform vec3 colors[5];\n"
+  "uniform float points[5];\n"
+  "\n"
+  "vec4 gradient_map (const vec4 color)\n"
+  "{\n"
+  "  if (color.a != 1.0)\n"
+  "  {\n"
+  "    return color;\n"
+  "  }\n"
+  "  const vec3 gray_conv = vec3 (0.299, 0.587, 0.114);\n"
+  "  float desaturated = dot (color.rgb, gray_conv);\n"
+  "  vec4 color_out = color;\n"
+  "  if (desaturated <= points[1])\n"
+  "  {\n"
+  "    color_out.rgb = mix (colors[0], colors[1], (desaturated - points[0]) / (points[1] - points[0]));\n"
+  "  }\n"
+  "  else if (desaturated <= points[2])\n"
+  "  {\n"
+  "    color_out.rgb = mix (colors[1], colors[2], (desaturated - points[1]) / (points[2] - points[1]));\n"
+  "  }\n"
+  "  else if (desaturated <= points[3])\n"
+  "  {\n"
+  "    color_out.rgb = mix (colors[2], colors[3], (desaturated - points[2]) / (points[3] - points[2]));\n"
+  "  }\n"
+  "  else\n"
+  "  {\n"
+  "    color_out.rgb = mix (colors[3], colors[4], (desaturated - points[3]) / (points[4] - points[3]));\n"
+  "  }\n"
+  "  return color_out;\n"
+  "}\n";
+
+static const gchar *glsl_source =
+  "  cogl_color_out.rgba = gradient_map (cogl_color_out.rgba);";
+
+
+G_DEFINE_TYPE_WITH_PRIVATE (HackfxCodeViewEffect,
+                            hackfx_code_view_effect,
+                            CLUTTER_TYPE_OFFSCREEN_EFFECT)
+
+static gboolean
+hackfx_code_view_effect_pre_paint (ClutterEffect       *effect,
+                                  ClutterPaintContext *paint_context)
+{
+  HackfxCodeViewEffect *self = HACKFX_CODE_VIEW_EFFECT (effect);
+  HackfxCodeViewEffectPrivate *priv = hackfx_code_view_effect_get_instance_private (self);
+  ClutterEffectClass *parent_class;
+
+  if (!clutter_actor_meta_get_enabled (CLUTTER_ACTOR_META (effect)))
+    return FALSE;
+
+  if (!clutter_feature_available (CLUTTER_FEATURE_SHADERS_GLSL))
+    {
+      /* if we don't have support for GLSL shaders then we
+       * forcibly disable the ActorMeta
+       */
+      g_warning ("Unable to use the ShaderEffect: the graphics hardware "
+                 "or the current GL driver does not implement support "
+                 "for the GLSL shading language.");
+      clutter_actor_meta_set_enabled (CLUTTER_ACTOR_META (effect), FALSE);
+      return FALSE;
+    }
+
+  parent_class = CLUTTER_EFFECT_CLASS (hackfx_code_view_effect_parent_class);
+  if (parent_class->pre_paint (effect, paint_context))
+    {
+      ClutterOffscreenEffect *offscreen_effect = CLUTTER_OFFSCREEN_EFFECT (effect);
+      CoglHandle texture;
+
+      texture = clutter_offscreen_effect_get_texture (offscreen_effect);
+      cogl_pipeline_set_layer_texture (priv->pipeline, 0, texture);
+
+      return TRUE;
+    }
+  else
+    return FALSE;
+}
+
+static void
+hackfx_code_view_effect_paint_target (ClutterOffscreenEffect *effect,
+                                     ClutterPaintContext    *paint_context)
+{
+  HackfxCodeViewEffect *self = HACKFX_CODE_VIEW_EFFECT (effect);
+  HackfxCodeViewEffectPrivate *priv = hackfx_code_view_effect_get_instance_private (self);
+  CoglFramebuffer *fb;
+  ClutterActor *actor;
+  CoglHandle texture;
+  guint8 paint_opacity;
+
+  texture = clutter_offscreen_effect_get_texture (effect);
+  cogl_pipeline_set_layer_texture (priv->pipeline, 0, texture);
+
+  actor = clutter_actor_meta_get_actor (CLUTTER_ACTOR_META (effect));
+  paint_opacity = clutter_actor_get_paint_opacity (actor);
+
+  fb = clutter_paint_context_get_framebuffer (paint_context);
+  cogl_pipeline_set_color4ub (priv->pipeline,
+                              paint_opacity,
+                              paint_opacity,
+                              paint_opacity,
+                              paint_opacity);
+  cogl_framebuffer_draw_rectangle (fb, priv->pipeline,
+                                   0, 0,
+                                   cogl_texture_get_width (texture),
+                                   cogl_texture_get_height (texture));
+}
+
+static void
+hackfx_code_view_effect_dispose (GObject *gobject)
+{
+  HackfxCodeViewEffect *self = HACKFX_CODE_VIEW_EFFECT (gobject);
+  HackfxCodeViewEffectPrivate *priv = hackfx_code_view_effect_get_instance_private (self);
+
+  g_clear_pointer (&priv->pipeline, cogl_object_unref);
+
+  G_OBJECT_CLASS (hackfx_code_view_effect_parent_class)->dispose (gobject);
+}
+
+static void
+update_gradient_uniforms (HackfxCodeViewEffect *self)
+{
+  HackfxCodeViewEffectPrivate *priv = hackfx_code_view_effect_get_instance_private (self);
+
+  if (!(priv->gradient_points_uniform > -1) || !(priv->gradient_colors_uniform > -1))
+    return;
+
+  cogl_pipeline_set_uniform_float (priv->pipeline,
+                                   priv->gradient_points_uniform,
+                                   1, /* n_components */
+                                   5, /* count */
+                                   priv->gradient_points);
+
+  float colors[15];
+
+  int i = 0;
+  for (int j = 0; j < 5; j++)
+    {
+      colors[i++] = priv->gradient_colors[j].red / 255.0;
+      colors[i++] = priv->gradient_colors[j].green / 255.0;
+      colors[i++] = priv->gradient_colors[j].blue / 255.0;
+    }
+
+  cogl_pipeline_set_uniform_float (priv->pipeline,
+                                   priv->gradient_colors_uniform,
+                                   3, /* n_components */
+                                   5, /* count */
+                                   colors);
+}
+
+static void
+hackfx_code_view_effect_class_init (HackfxCodeViewEffectClass *klass)
+{
+  ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  ClutterOffscreenEffectClass *offscreen_class;
+
+  offscreen_class = CLUTTER_OFFSCREEN_EFFECT_CLASS (klass);
+  offscreen_class->paint_target = hackfx_code_view_effect_paint_target;
+
+  effect_class->pre_paint = hackfx_code_view_effect_pre_paint;
+
+  gobject_class->dispose = hackfx_code_view_effect_dispose;
+}
+
+static void
+hackfx_code_view_effect_init (HackfxCodeViewEffect *self)
+{
+  HackfxCodeViewEffectClass *klass = HACKFX_CODE_VIEW_EFFECT_GET_CLASS (self);
+  HackfxCodeViewEffectPrivate *priv = hackfx_code_view_effect_get_instance_private (self);
+
+  if (G_UNLIKELY (klass->base_pipeline == NULL))
+    {
+      CoglContext *ctx =
+        clutter_backend_get_cogl_context (clutter_get_default_backend ());
+      CoglSnippet *snippet;
+
+      klass->base_pipeline = cogl_pipeline_new (ctx);
+
+      snippet = cogl_snippet_new (COGL_SNIPPET_HOOK_FRAGMENT,
+                                  glsl_declarations,
+                                  glsl_source);
+      cogl_pipeline_add_snippet (klass->base_pipeline, snippet);
+      cogl_object_unref (snippet);
+
+      cogl_pipeline_set_layer_null_texture (klass->base_pipeline, 0);
+    }
+
+  priv->pipeline = cogl_pipeline_copy (klass->base_pipeline);
+
+  priv->gradient_colors_uniform =
+    cogl_pipeline_get_uniform_location (priv->pipeline, "colors");
+  priv->gradient_points_uniform =
+    cogl_pipeline_get_uniform_location (priv->pipeline, "points");
+
+  update_gradient_uniforms (self);
+}
+
+/**
+ * hackfx_code_view_effect_set_gradient_stops:
+ * @effect: a #HackfxCodeViewEffect
+ * @gradient_colors: (array length=gradient_len) (element-type utf8): gradient colors
+ * @gradient_points: (array length=gradient_len) (element-type gfloat): gradient points
+ * @gradient_len: length of gradient stops
+ *
+ * Set the gradient colors and stop points for this effect.
+ */
+void
+hackfx_code_view_effect_set_gradient_stops (HackfxCodeViewEffect *effect,
+                                           gchar **gradient_colors,
+                                           gfloat *gradient_points,
+                                           gsize gradient_len)
+{
+  HackfxCodeViewEffectPrivate *priv = hackfx_code_view_effect_get_instance_private (effect);
+  gint i;
+
+  g_return_if_fail (gradient_colors != NULL);
+  g_return_if_fail (gradient_points != NULL);
+  g_return_if_fail (gradient_len == 5);
+
+  memcpy (priv->gradient_points, gradient_points, sizeof (gfloat) * gradient_len);
+  for (i = 0; i < gradient_len; i++)
+    clutter_color_from_string (&priv->gradient_colors[i], gradient_colors[i]);
+
+  update_gradient_uniforms (effect);
+}
+
+/**
+ * hackfx_code_view_effect_new:
+ *
+ * Creates a new #HackfxCodeViewEffect to be used with
+ * clutter_actor_add_effect()
+ *
+ * Return value: the newly created #HackfxCodeViewEffect or %NULL
+ */
+ClutterEffect *
+hackfx_code_view_effect_new (void)
+{
+  return g_object_new (HACKFX_TYPE_CODE_VIEW_EFFECT, NULL);
+}

--- a/src/hackfx-code-view-effect.h
+++ b/src/hackfx-code-view-effect.h
@@ -1,0 +1,49 @@
+/*
+ * hackfx-code-view-effect.h
+ *
+ * Based on clutter-desaturate-effect.h.
+ *
+ * Copyright (C) 2010  Intel Corporation.
+ * Copyright (C) 2018  Endless Mobile, Inc.
+ * Copyright (C) 2020  Endless OS LLC.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *   Emmanuele Bassi <ebassi@linux.intel.com>
+ *   Cosimo Cecchi <cosimo@endlessm.com>
+ *   Daniel Garcia Moreno <daniel@endlessm.com>
+ */
+
+#ifndef __HACKFX_CODE_VIEW_EFFECT_H__
+#define __HACKFX_CODE_VIEW_EFFECT_H__
+
+#include <clutter/clutter.h>
+
+G_BEGIN_DECLS
+
+#define HACKFX_TYPE_CODE_VIEW_EFFECT (hackfx_code_view_effect_get_type ())
+G_DECLARE_DERIVABLE_TYPE (HackfxCodeViewEffect, hackfx_code_view_effect,
+                          HACKFX, CODE_VIEW_EFFECT, ClutterOffscreenEffect)
+
+ClutterEffect *hackfx_code_view_effect_new      (void);
+
+void hackfx_code_view_effect_set_gradient_stops (HackfxCodeViewEffect *effect,
+                                                 gchar **gradient_colors,
+                                                 gfloat *gradient_points,
+                                                 gsize gradient_len);
+
+G_END_DECLS
+
+#endif /* __HACKFX_CODE_VIEW_EFFECT_H__ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,95 @@
+shell_version = '3.36.0'
+split_version = shell_version.split('.')
+
+# We depend on a specific version of the libmutter API. The mutter variants of
+# the Cogl and Clutter libraries also use this API version.
+# The API version is increased automatically each development cycle,
+# starting with 0 in 3.23.x
+api_version = (split_version[1].to_int() - 23) / 2
+mutter_api_version = '@0@'.format(api_version)
+
+clutter_pc = 'mutter-clutter-' + mutter_api_version
+cogl_pc = 'mutter-cogl-' + mutter_api_version
+libmutter_pc = 'libmutter-' + mutter_api_version
+
+mutter_req = '>= 3.36.0'
+
+gnome = import('gnome')
+i18n  = import('i18n')
+
+prefix = get_option('prefix')
+
+mutter_dep = dependency(libmutter_pc, version: mutter_req)
+clutter_dep = dependency(clutter_pc, version: mutter_req)
+cogl_dep = dependency(cogl_pc, version: mutter_req)
+
+cc = meson.get_compiler('c')
+
+# Endless-specific: Custom animations
+libanimation_glib_dep = dependency('libanimation-glib-0')
+libeos_shell_fx_deps = [clutter_dep, libanimation_glib_dep]
+
+hackfx_deps = [
+  clutter_dep,
+  cogl_dep,
+  mutter_dep,
+]
+
+hackfx_cflags = [
+  '-DCLUTTER_ENABLE_EXPERIMENTAL_API',
+  '-DCOGL_ENABLE_EXPERIMENTAL_API',
+  '-DVERSION="@0@"'.format(meson.project_version()),
+]
+
+libhackfx_public_headers = [
+  'hackfx-code-view-effect.h',
+]
+
+libhackfx_private_headers = [
+]
+
+libhackfx_private_sources = [
+]
+
+libhackfx_sources = [
+  'hackfx-code-view-effect.c',
+]
+
+libhackfx_enums = gnome.mkenums_simple('hackfx-enum-types',
+  sources: libhackfx_public_headers
+)
+
+libhackfx_gir_sources = [
+  libhackfx_enums,
+  libhackfx_public_headers,
+  libhackfx_sources
+]
+
+libhackfx_no_gir_sources = [
+  libhackfx_private_headers,
+  libhackfx_private_sources
+]
+
+libhackfx = shared_library('hackfx',
+  sources: libhackfx_gir_sources + libhackfx_no_gir_sources,
+  dependencies: hackfx_deps,
+  c_args: hackfx_cflags,
+  install: true
+)
+
+libhackfx_dep = declare_dependency(link_with: libhackfx)
+
+libhackfx_gir_includes = [
+  'Clutter-@0@'.format(mutter_api_version),
+  'ClutterX11-@0@'.format(mutter_api_version),
+  'Meta-@0@'.format(mutter_api_version),
+]
+
+gnome.generate_gir(libhackfx,
+  sources: libhackfx_gir_sources,
+  nsversion: '0.1',
+  namespace: 'Hackfx',
+  includes: libhackfx_gir_includes,
+  extra_args: ['--quiet'],
+  install: true
+)

--- a/ui/codeView.js
+++ b/ui/codeView.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 /* exported enable, disable */
 
-const { Clutter, Graphene, Gio, GLib, GObject, Gtk, Meta, Shell, St } = imports.gi;
+const { Clutter, Graphene, Gio, GLib, GObject, Gtk, Hackfx, Meta, Shell, St } = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Hack = ExtensionUtils.getCurrentExtension();
@@ -34,12 +34,12 @@ const FLIP_BUTTON_PULSE_SPEED = 100;
 const _HACK_SHADER_MAP = {
     none: null,
     desaturate: {
-        constructor: Shell.CodeViewEffect,
+        constructor: Hackfx.CodeViewEffect,
         colors: ['#05213f', '#031c39', '#00275c', '#8d6531', '#f4f1a2'],
         points: [0.00, 0.07, 0.32, 0.65, 1.00],
     },
     fizzics: {
-        constructor: Shell.CodeViewEffect,
+        constructor: Hackfx.CodeViewEffect,
         colors: ['#05213f', '#031c39', '#114283', '#b27220', '#f4f1a2'],
         points: [0.00, 0.10, 0.20, 0.60, 1.00],
     },


### PR DESCRIPTION
This patch adds a new C library to the project, hackfx. This library
will have clutter effect that are used in the extension and right now
are in the gnome-shell endless branch.

This first commit copies the shell_code_view_effect class from the shell
here and it's renamed to hackfx_code_view_effect.

https://phabricator.endlessm.com/T30450