### PR TITLE
appDisplay: Don't show icon when blocked on parental control

### DIFF
--- a/ui/appDisplay.js
+++ b/ui/appDisplay.js
@@ -7,6 +7,7 @@ const IconGridLayout = imports.ui.iconGridLayout;
 const DND = imports.ui.dnd;
 const PopupMenu = imports.ui.popupMenu;
 const Main = imports.ui.main;
+const ParentalControlsManager = imports.misc.parentalControlsManager;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Hack = ExtensionUtils.getCurrentExtension();
@@ -17,9 +18,12 @@ const _ = Hack.imports.utils.gettext;
 const Clubhouse = Hack.imports.ui.clubhouse;
 
 function _shouldShowHackLauncher() {
+    const parentalControlsManager = ParentalControlsManager.getDefault();
+    const app = Clubhouse.getClubhouseApp();
+
     // Only show the hack icon if the clubhouse app is in the system
     const show = Settings.get_boolean('show-hack-launcher');
-    return show && Clubhouse.getClubhouseApp();
+    return show && app && parentalControlsManager.shouldShowApp(app.app_info);
 }
 
 var HackAppIcon = GObject.registerClass(


### PR DESCRIPTION
The clubhouse could be blocked on the parental control. In that case we
shouldn't show the hack icon on the desktop.

https://phabricator.endlessm.com/T30504