### PR TITLE
codeView: Do not attempt to add panel button if no window is available

### DIFF
--- a/ui/codeView.js
+++ b/ui/codeView.js
@@ -1865,6 +1865,9 @@ function proxyApp(...args) {
 
 function addButton(app) {
     const [win] = app.get_windows();
+    if (!win)
+        return;
+
     const proxy = _getHackToolboxProxy(win);
     // This is a toolbox! we don't want to show toolboxes in the icon bar
     if (proxy)


### PR DESCRIPTION
This fixes the following warning:
```
  gnome-shell[1512]: JS ERROR: TypeError: win is undefined
                     _getHackToolboxProxy@/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/ui/codeView.js:129:25
                     addButton@/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/ui/codeView.js:1868:19
                     _onAppStateChanged@/usr/share/gnome-shell/extensions/eos-panel@endlessm.com/ui/appIconBar.js:949:18
```