### PR TITLE
service: Fix check for gnome-shell 3.36 on EOS

### DIFF
--- a/service.js
+++ b/service.js
@@ -350,7 +350,7 @@ function enable() {
 
 function disable() {
     // TODO: integrate with eos-desktop@endlessm.com
-    if (!Utils.desktopIs('endless', '3.36'))
+    if (Utils.desktopIs('endless', '3.36'))
         Utils.restore(ShellDBus.AppStoreService);
 
     if (SHELL_DBUS_SERVICE) {


### PR DESCRIPTION
The ShellDBus.AppStoreService is no longer available on latest Shell.

This fixes the following warning:
```
  gnome-shell[4350]: JS WARNING: [/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/service.js 354]: reference to undefined property "AppStoreService"
  gnome-shell[4350]: JS ERROR: Extension eos-hack@endlessm.com: TypeError: object is undefined
                     restore@/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/utils.js:134:24
                     disable@/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/service.js:354:15
                     disable@/usr/share/gnome-shell/extensions/eos-hack@endlessm.com/extension.js:72:13
                     _callExtensionDisable@resource:///org/gnome/shell/ui/extensionSystem.js:109:32
                     _onEnabledExtensionsChanged/<@resource:///org/gnome/shell/ui/extensionSystem.js:502:45
                     _onEnabledExtensionsChanged@resource:///org/gnome/shell/ui/extensionSystem.js:502:24
                     _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:634:18
                     _emit@resource:///org/gnome/gjs/modules/core/_signals.js:133:47
                     _sync@resource:///org/gnome/shell/ui/sessionMode.js:214:14
                     pushMode@resource:///org/gnome/shell/ui/sessionMode.js:175:14
                     activate@resource:///org/gnome/shell/ui/screenShield.js:642:34
                     lock@resource:///org/gnome/shell/ui/screenShield.js:707:14
                     activateLockScreen@resource:///org/gnome/shell/misc/systemActions.js:408:27
                     _createSubMenu/<@resource:///org/gnome/shell/ui/status/system.js:107:33
                     activate@resource:///org/gnome/shell/ui/popupMenu.js:191:14
                     vfunc_button_release_event@resource:///org/gnome/shell/ui/popupMenu.js:138:14
```