### PR TITLE
tooltip: Remove tooltip on disable

### DIFF
--- a/stylesheet.scss
+++ b/stylesheet.scss
@@ -204,8 +204,8 @@ $clubhouse_action_buttons_color_active: #44D7B6;
 }
 
 .hack-tooltip-arrow {
-  -arrow-background-color: white;
-  -arrow-border-color: transparent;
+  -arrow-background-color: white !important;
+  -arrow-border-color: transparent !important;
 }
 
 .hack-tooltip {


### PR DESCRIPTION
The tooltip should be removed and readded when the extension is
disabled/enabled to not have the tooltip when the extension is disabled.

This will fix the issue with lock/unlock the screen because almost all
extensions are disabled in the lock screen.

https://phabricator.endlessm.com/T30792