### PR TITLE
clubhouse: Initialize onboarding proxy asynchronously

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -47,14 +47,14 @@ const Service = Hack.imports.service;
 function enable() {
     tryMigrateSettings();
 
-    // Hack clubhouse desktop notifications
-    ui.clubhouse.enable();
-
     // Flip to hack
     ui.codeView.enable();
 
     // DBus API
     Service.enable();
+
+    // Hack clubhouse desktop notifications
+    ui.clubhouse.enable();
 }
 
 function disable() {


### PR DESCRIPTION
Using the synchronous version may take a really long time - seconds,
even.

This patch moves the code to create the onboarding extension proxy to a
new asynchronous function and await on the async loading of the proxy.

https://phabricator.endlessm.com/T30788