### PR TITLE
Add all sources in zip-file target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ sources = [
 extra_sources = [
   'COPYING',
 ]
+dist_files = sources + extra_sources
+dist_files += ['ui', 'misc', 'data']
 
 i18n = import('i18n')
 subdir('locale')
@@ -99,7 +101,7 @@ if extension_tool.found()
     '--extra-source=@0@/metadata.json'.format(builddir)
   ]
 
-  foreach s : extra_sources
+  foreach s : dist_files
     command += '--extra-source=@0@'.format(s)
   endforeach
 


### PR DESCRIPTION
The `ninja zip-file` command creates a zip with the `gnome-extensions` tool. That zip should have the extension to be installed in a gnome-shell.

This patch add all the needed files to the final zip, all sources and data.

https://phabricator.endlessm.com/T30449