### PR TITLE
utils: Reset hack desktop modifications

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -41,10 +41,11 @@ const Hack = ExtensionUtils.getCurrentExtension();
 
 // To import custom files
 const {ui} = Hack.imports;
-const {tryMigrateSettings, desktopIs} = Hack.imports.utils;
+const {tryMigrateSettings, desktopIs, checkHackBg} = Hack.imports.utils;
 const Service = Hack.imports.service;
 
 function enable() {
+    resetHackMods();
     tryMigrateSettings();
 
     // Flip to hack

--- a/utils.js
+++ b/utils.js
@@ -267,3 +267,25 @@ function runWithExtension(extension, callback) {
     callback(loaded);
     return true;
 }
+
+// Looks for old clubhouse system modifications and reset to the EOS default.
+// This only works on endless desktop and it's to ease the migration from
+// EOS 3.8 to EOS 3.9.
+//
+// This is needed because the old clubhouse changes the user background and the
+// cursor-theme on the first run.
+function resetHackMods() {
+    if (!desktopIs('endless'))
+        return;
+
+    let settings = Gio.Settings.new('org.gnome.desktop.background');
+    const clubhouseBG = 'file:///var/lib/flatpak/app/com.hack_computer.Clubhouse';
+    const bg = settings.get_string('picture-uri');
+
+    if (bg.startsWith(clubhouseBG))
+        settings.reset('picture-uri');
+
+    settings = Gio.Settings.new('org.gnome.desktop.interface');
+    if (settings.get_string('cursor-theme') === 'cursor-hack')
+        settings.reset('cursor-theme');
+}


### PR DESCRIPTION
The clubhouse changed the background and cursor theme on hack mode
enable / disable change. The hack mode has been removed and the
clubhouse doesn't change the background and cursor theme anymore.

This patch adds some code to the extension to ensure to reset the
modified values from a previous clubhouse version and will avoid
problems in the future if we remove the background images from the
clubhouse.

https://phabricator.endlessm.com/T30736