### PR TITLE
clubhouse: Fix url parsing on markup

### DIFF
--- a/ui/clubhouse.js
+++ b/ui/clubhouse.js
@@ -1118,9 +1118,12 @@ var Component = GObject.registerClass({
 // rich markup
 function _fixMarkup(text, allowMarkup, onlySimpleMarkup) {
     if (allowMarkup) {
+        // Remove a tag with the content, we'll parse urls using Util.findUrls
+        let _text = text.replace(/<a .*>(.*)<\/a>/g, '$1');
+
         // Support &amp;, &quot;, &apos;, &lt; and &gt;, escape all other
         // occurrences of '&'.
-        let _text = text.replace(/&(?!amp;|quot;|apos;|lt;|gt;)/g, '&amp;');
+        _text = _text.replace(/&(?!amp;|quot;|apos;|lt;|gt;)/g, '&amp;');
 
         if (onlySimpleMarkup) {
             // Support <b>, <i>, and <u>, escape anything else


### PR DESCRIPTION
The 'a' tag is not valid for pango on the shell, so we should remove
every 'a' tag on the text before calling Pango.parse_markup to avoid an
Error.

This patch just removes all 'a' tags and leave the text inside the tag.
The clubhouse shell notification code parses all links and convert them
into clickable widgets, so this will fix the issue with links not
working.

https://phabricator.endlessm.com/T31032

This is a regression produced by the change from clubhouse window notifications to the shell notifications. We added the `a href` tag wrapping every [quest link on the clubhouse](https://github.com/endlessm/clubhouse/pull/1167/commits) to make links work with in-app notifications, but when we go back to shell extension notifications we found that those links are not working correctly.

This patch just fixes the issue in the shell extension so this strings will work, and also the strings without the `a` tag.