### PR TITLE
Disable forward compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -36,6 +36,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
+const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Hack = ExtensionUtils.getCurrentExtension();
 
@@ -45,6 +46,12 @@ const {tryMigrateSettings, resetHackMods} = Hack.imports.utils;
 const Service = Hack.imports.service;
 
 function enable() {
+    // Disable forward compatibility, 40 and forward
+    const shellVersion = Config.PACKAGE_VERSION;
+    if (shellVersion >= '3.39') {
+        throw new Error('Incompatible shell version > 3.38');
+    }
+
     resetHackMods();
     tryMigrateSettings();
 


### PR DESCRIPTION
The forward compatibility is enabled by default on major linux
distributions like Ubuntu or Fedora, this keys is true:

disable-extension-version-validation

To avoid breaking the system with the hack extension on update, this
patch introduces a check that will disable the extension if the version
is greater than expected.

We'll need to review and adapt the code for future versions before the
release to keep the extension working with OS updates.

https://phabricator.endlessm.com/T31135