### PR TITLE
meson: Drop unnecessary variable 'shell_version'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,6 @@ have_schemas = schemas.length() > 0
 metaconf = configuration_data()
 metaconf.set('uuid', uuid)
 metaconf.set('version', 1)
-metaconf.set('shell_version', meson.project_version())
 if have_schemas
   metaconf.set('settings_schema', schemas[0])
 endif


### PR DESCRIPTION
The 'shell-version' field in metadata.json is not parametrized anymore, so try to set it from the build system is a no-op.